### PR TITLE
autoextract: better response to ^C/cancellation (#29)

### DIFF
--- a/src/autoanalyze
+++ b/src/autoanalyze
@@ -140,7 +140,7 @@ MFFTEMPDIR="$(mktemp -d)" || {
 	echo 'Unable to create temporary directory. Exiting.' >&2
 	exit 1
 }
-trap 'cleanup' EXIT HUP INT QUIT TERM
+trapforcleanup
 
 echo "Downloading Il2CppInspector..." >"$VERBOSEOUT"
 I2CIDIR="$MFFTEMPDIR/Il2CppInspector"

--- a/src/autoextract
+++ b/src/autoextract
@@ -80,7 +80,7 @@ if [ -d "$MFFTEMPDIR" ]; then
 	if [ -n "$(find "$MFFTEMPDIR" ! -path "$MFFTEMPDIR")" ]; then
 		throwfatal "Temporary directory '$MFFTEMPDIR' is not empty. Exiting."
 	fi
-	trap 'rm -rf "$MFFTEMPDIR"; kill -- -$$' EXIT HUP INT QUIT TERM
+	trapforcleanup
 else
 	throwfatal "Unable to create temporary directory. Exiting."
 fi

--- a/src/common.sh
+++ b/src/common.sh
@@ -10,6 +10,8 @@
 # should be created before calling getdir if necessary.
 #
 # TODO: #91 Consider whether we need to deal with paths ending in /
+# Can probably implement algorithm used by cd, as in:
+# https://pubs.opengroup.org/onlinepubs/9699919799/
 getdir() {
 	if [ "$#" != "1" ]; then
 		echo 'Usage: getdir dirname' >&2
@@ -41,4 +43,67 @@ throwfatal() {
 		echo "$0": "$@" >&2
 	fi
 	exit 1
+}
+
+cleanup() {
+	if [ "$#" -gt "1" ]; then
+		echo 'Usage: cleanup [signal]' >&2
+		return 1
+	fi
+	case "$1" in
+		"" | HUP | INT | QUIT | TERM) ;;
+		*)
+			echo "'$1' is an unsupported signal" >&2
+			return 1
+			;;
+	esac
+	echo "Cleaning up" >"$VERBOSEOUT"
+	# Temp directories may still be in use by child processes
+	trap '' EXIT HUP INT QUIT TERM
+	kill -s "$1" 0
+	# Allow cancelling further if, e.g., someone hits Ctrl-C while cleanup is
+	# happening
+	trap - EXIT HUP INT QUIT TERM
+	wait
+	[ -n "$MFFTEMPDIR" ] && {
+		rm -rf -- "$MFFTEMPDIR" || echo "Unable to complete cleanup" >&2
+	}
+	if [ -n "$1" ]; then
+		kill -s "$1" 0
+		# Shells do not portably exit despite POSIX specification
+		# on some of the above signals (e.g., bash ignores SIGQUIT)
+		exit 1
+	fi
+	exit
+}
+signal() {
+	if [ "$#" != "1" ]; then
+		echo 'Usage: signal signalname' >&2
+		return 1
+	fi
+	signal=""
+	case "$1" in
+		"HUP" | "INT" | "QUIT" | "TERM")
+			signal="$1"
+			;;
+		"EXIT") ;;
+		*)
+			echo 'Usage: signal signalname' >&2
+			return 1
+			;;
+	esac
+	trap '' EXIT
+	echo "Processing $1 signal" >"$VERBOSEOUT"
+	if [ -n "$signal" ]; then
+		cleanup "$signal"
+	else
+		cleanup
+	fi
+}
+trapforcleanup() {
+	trap cleanup EXIT
+	trap 'signal HUP' HUP
+	trap 'signal INT' INT
+	trap 'signal QUIT' QUIT
+	trap 'signal TERM' TERM
 }


### PR DESCRIPTION
- added cleaner (and "more correct") traps for exiting scripts
  and moved to common.sh, referenced in autoextract and autoanalyze