### PR TITLE
Get rid of emulator use

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -139,6 +139,7 @@ in the [Tools](#tools) section of [Writing code](#writing-code).
 -   [Node.js with npm](https://nodejs.dev) (with the `npm` command in your path)
 -   [Google account](https://myaccount.google.com/) with access to [Google Apps Script](https://script.google.com/)
 -   [git](https://git-scm.com)
+-   Python 3
 -   a vaguely modern computer with an undetermined minimum quantity of RAM that
     is probably several gigabytes
 
@@ -154,6 +155,7 @@ requirements for running the programs themselves additionally include:
     (required for `autoanalyze`)
 -   Java 11 runtime or SDK (required for `autoextract` and Ghidra); consider
     [Temurin 11](https://adoptium.net/?variant=openjdk11&jvmVariant=hotspot)
+-   Python 3 (required for `autoextract`)
 
 ### Recommendations
 

--- a/docs/autoextract.md
+++ b/docs/autoextract.md
@@ -41,10 +41,13 @@ output that includes echoing all shell commands in `autoextract` and printing
 the verbose output from each individual tool called. Adding further `-v` options
 has no effect.
 
-The final product created by `autoextract` is a directory named
-`mff-device-files-`_`version`_ within _`output_directory`_. This contains a copy
-of all Marvel Future Fight files installed by the game on Android devices in a
-directory hierarchy copied directly from the Android emulator's filesystem.
+The final product created by `autoextract` are directories named
+`mff-device-files-`_`version`_ and `apks` within _`output_directory`_. The
+former contains a copy of all Marvel Future Fight files installed by the game on
+Android devices in a directory hierarchy copied directly from the Android
+emulator's filesystem. The latter contains only the installation packages used
+to install the software, downloaded separately without using the Android
+emulators for testing and further development of `mffer`.
 
 ## Requirements
 
@@ -55,6 +58,7 @@ directory hierarchy copied directly from the Android emulator's filesystem.
     Parallels or VirtualBox.
 -   Internet connection with access to Google developer tools, Google
     Play Store, and Netmarble servers
+-   Python 3 (required to download MFF without Android tools)
 -   Java (required by Android command-line tools)
 -   A Google account (to log into the Play store)
 -   A reasonable machine upon which to run these; see also the

--- a/src/scripts/autoextract
+++ b/src/scripts/autoextract
@@ -18,12 +18,10 @@ description() {
 	echo "	-v	print more information; specify twice for debug output"
 }
 
-# shbuild replace common.sh
 # shellcheck source=./common.sh
 if [ -r "$(dirname "$0")"/common.sh ]; then
 	. "$(dirname "$0")"/common.sh
 fi
-# shbuild end replace common.sh
 
 DEBUG=""
 VERBOSE=""
@@ -101,6 +99,57 @@ if ! mkdir -p -- "$MFFOUTPUTDIR" >"$DEBUGOUT" 2>&1; then
 	exit 1
 fi
 MFFOUTPUTDIR="$(getdir "$MFFOUTPUTDIR")"
+
+echo "Getting MFF from the Google Play Store..." >"$VERBOSEOUT"
+if ! PYTHON3="$(which python3)" >"$DEBUGOUT" 2>&1; then
+	echo "Error: unable to locate python3 executable" >&2
+	exit 1
+fi
+if ! "$PYTHON3" -m venv "$MFFTEMPDIR/python"; then
+	echo "Error: unable to create temporary python environment" >&2
+	exit 1
+fi
+if [ -r "$MFFTEMPDIR/python/bin/activate" ]; then
+	# shellcheck disable=SC1091
+	. "$MFFTEMPDIR"/python/bin/activate
+	if ! python; then
+		echo "Error: could not run python3." >&2
+		exit 1
+	fi <<EOF
+import string
+import sys
+if sys.prefix == sys.base_prefix:
+    print( "Not in a virtual environment", file=sys.stderr)
+    exit(1)
+if not sys.prefix.startswith( "$MFFTEMPDIR" ) and not sys.prefix.startswith( "/private$MFFTEMPDIR" ):
+    print( "Not running in $MFFTEMPDIR", file=sys.stderr)
+    print( "(sys.prefix=" + sys.prefix +")")
+    exit(1)
+if sys.version_info.major != 3:
+    print( "Not running in Python 3", file=sys.stderr)
+    exit(1)
+EOF
+fi
+
+if ! pip3 install --upgrade --force-reinstall gplaydl==1.3.5 >"$DEBUGOUT" 2>&1 \
+	|| ! echo "Enter a Google account username and password to download MFF." \
+	|| ! echo "(You'll need an app password to allow access to this program.)" \
+	|| ! printf 'Google Email: ' \
+	|| ! gplaydl configure >"$DEBUGOUT" \
+	|| ! gplaydl download --packageId com.netmarble.mherosgb --path "$MFFTEMPDIR" >"$DEBUGOUT"; then
+	echo "Unable to download MFF" >&2
+	exit 1
+fi
+BASEAPK="$MFFTEMPDIR"/com.netmarble.mherosgb.apk
+for file in "$MFFTEMPDIR"/com.netmarble.mherosgb/config.*.apk; do
+	SPLITAPK="$file"
+done
+if [ ! -f "$BASEAPK" ] || [ ! -f "$SPLITAPK" ]; then
+	echo "MFF download files are invalid" >&2
+	exit 1
+fi
+mkdir -p "$MFFOUTPUTDIR"/apks
+mv "$BASEAPK" "$SPLITAPK" "$MFFOUTPUTDIR"/apks
 
 MFF_ANDROID_SDK_URL_BASE='https://dl.google.com/android/repository/'
 if [ x = "${MFF_OS}x" ]; then


### PR DESCRIPTION
Emulator doesn't work properly as nested VM, so getting rid of to be able to test the program properly within VMs. (Also, it's annoying and requires far too much interaction.)

- [x] test to ensure python download of apks is equivalent to pulling from emulator 
  *Yup, exactly the same*
- [x] test to ensure other files are acceptable alternative to pulling from emulator
  *Yup, mffer pulls most of what's needed already, just about everything extra that the emulator gets even with running and downloading stuff is extraneous and not (currently) evaluated by mffer---see also docs/notes*
- [x] update list of requiremed software (e.g., include python, get rid of java?)
  *Documented in autoextract.md list of requirements, but not changing other stuff for now that will need larger update after major v0.2.0 merge*
- [x] consider whether this requires merge with networking branch or just delay
  *will start merging things into a master 0.2.0 branch*