### PR TITLE
Update AssetsTools.NET

### DIFF
--- a/mffer.csproj
+++ b/mffer.csproj
@@ -14,7 +14,7 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);docs/**;tools/**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="AssetsTools.NET" Version="2.0.11" />
+	<PackageReference Include="AssetsTools.NET" Version="3.0-preview2" />
 	<PackageReference Include="Community.Archives.Apk" Version="1.2.0" />
 	<PackageReference Include="GooglePlayStoreApi" Version="1.0.7" />
     <PackageReference Include="MessagePack" Version="2.2.85" />


### PR DESCRIPTION
MFF 8.7.0 (and possibly earlier) assets are not readable by
AssetsTools.NET 2.0.11; update to 3.0-preview2 requires several API changes
to AssetsTools.NET but no significant logic changes in mffer