### PR TITLE
Allow specifying asset by class name

### DIFF
--- a/src/classes/AssetBundle.cs
+++ b/src/classes/AssetBundle.cs
@@ -77,8 +77,7 @@ namespace Mffer {
 		public bool Contains( string name ) {
 			if ( String.IsNullOrEmpty( name ) ) throw new ArgumentNullException( nameof( name ) );
 			if ( Assets.ContainsKey( name ) ) return true;
-			GetAllAssetNames();
-			return Assets.ContainsKey( name );
+			return assetReader.Contains( name, this );
 		}
 		/// <summary>
 		/// Obtains a list of the names of all <see cref="Assets"/>s included in
@@ -87,16 +86,15 @@ namespace Mffer {
 		/// <remarks>
 		/// This method does not report whether data for the listed <see
 		/// cref="Asset"/>s has been loaded into the instance, only which <see
-		/// cref="Asset"/>s are accessible within the <see cref="AssetBundle"/>
+		/// cref="Asset"/>s are accessible within the <see cref="AssetBundle"/>.
+		/// Additionally, this returns only the names of included assets, not
+		/// the (possible) aliased class names.
 		/// </remarks>
 		/// <returns><see cref="List{String}"/> containing all <see
 		/// cref="Asset"/> names accessible within this <see
 		/// cref="AssetBundle"/></returns>
 		public List<string> GetAllAssetNames() {
 			List<string> assetNames = assetReader.GetAllAssetNames( this );
-			foreach ( string name in assetNames ) {
-				if ( !Assets.ContainsKey( name ) ) Assets.Add( name, null );
-			}
 			return assetNames;
 		}
 		/// <summary>
@@ -106,8 +104,12 @@ namespace Mffer {
 		/// <returns>The asset named <paramref name="name"/></returns>
 		public Asset GetAsset( string name ) {
 			if ( String.IsNullOrEmpty( name ) ) throw new ArgumentNullException( nameof( name ) );
-			if ( !Assets.ContainsKey( name ) || Assets[name] is null || Assets[name].Value is null ) Assets[name] = assetReader.GetAsset( name, this );
-			return Assets[name];
+			if ( Assets.ContainsKey( name )
+				&& Assets[name] is not null
+				&& Assets[name].Value is not null )
+				return Assets[name];
+			else
+				return assetReader.GetAsset( name, this );
 		}
 		/// <summary>
 		/// Obtains all data accessible within this <see cref="AssetBundle"/> as
@@ -117,13 +119,7 @@ namespace Mffer {
 		/// <see cref="AssetBundle"/>, with all their data fully
 		/// loaded</returns>
 		public List<Asset> GetAllAssets() {
-			GetAllAssetNames();
-			foreach ( string key in Assets.Keys ) {
-				if ( Assets[key] is null || Assets[key].Value is null ) {
-					Assets[key] = GetAsset( key );
-				}
-			}
-			return Assets.Values.ToList();
+			return assetReader.GetAllAssets( this );
 		}
 	}
 }

--- a/src/classes/AssetsToolsNETReader.cs
+++ b/src/classes/AssetsToolsNETReader.cs
@@ -31,7 +31,13 @@ namespace Mffer {
 		/// <inheritdoc/>
 		public bool Contains( string name, AssetBundle assetBundle ) {
 			CheckAssetBundle( assetBundle );
-			return assetBundles[assetBundle.Path].AssetInfo.ContainsKey( name );
+			return Contains( name, assetBundles[Path.GetFullPath( assetBundle.Path )] );
+		}
+		private bool Contains( string name, AssetsToolsNETBundle assetBundle ) {
+			if ( assetBundle.AssetInfo.ContainsKey( name ) ) return true;
+			if ( assetBundle.Classes.ContainsKey( name )
+				&& assetBundle.AssetInfo.ContainsKey( assetBundle.Classes[name] ) ) return true;
+			return false;
 		}
 		/// <inheritdoc/>
 		/// <exception cref="ArgumentNullException"> if <paramref name="path"/>
@@ -62,21 +68,39 @@ namespace Mffer {
 				// since we never load an asset bundle without looking for
 				// assets
 				AssetsFileInstance assetFileInst = assetsManager.LoadAssetsFileFromBundle( assetsBundleInstance, 0 );
-				List<AssetFileInfo> assetBundleInfos = assetFileInst.file.GetAssetsOfType( (int)AssetClassID.AssetBundle );
+				List<AssetFileInfo> assetBundleInfos = assetFileInst.file.GetAssetsOfType( AssetClassID.AssetBundle );
 				if ( assetBundleInfos.Count != 1 ) throw new NotSupportedException( $"Unable to evaluate asset bundle '{path}'; bundle catalog is invalid." );
 				AssetTypeValueField assetInfoArray = assetsManager.GetBaseField( assetFileInst, assetBundleInfos[0] ).Get( "m_Container" ).Get( "Array" );
 				Dictionary<long, string> assetIDs = new();
+				Dictionary<long, AssetTypeValueField> assetCatalog = new();
 				foreach ( AssetTypeValueField asset in assetInfoArray.Children ) {
 					assetIDs.Add( asset[1].Get( "asset" ).Get( "m_PathID" ).Value.AsLong, asset[0].AsString );
+					assetCatalog.Add( asset[1].Get( "asset" ).Get( "m_PathID" ).Value.AsLong, asset );
 				}
-				foreach ( AssetFileInfo asset in assetFileInst.file.AssetInfos ) {
-					if ( assetIDs.ContainsKey( asset.PathId ) ) {
+				foreach ( AssetFileInfo asset in assetFileInst.file.GetAssetsOfType( AssetClassID.TextAsset ) ) {
+					if ( !assetIDs.ContainsKey( asset.PathId ) ) {
+						throw new KeyNotFoundException( $"Unable to identify asset with path ID {asset.PathId}" );
+					} else {
 						assetsToolsNETBundle.AssetInfo.Add(
 							assetIDs[asset.PathId],
 							asset
 						);
 					}
-					// probably still need to do something here with MonoBehaviors & MonoScripts
+				}
+				Dictionary<long, string> scriptClasses = new();
+				foreach ( AssetFileInfo script in assetFileInst.file.GetAssetsOfType( AssetClassID.MonoScript ) ) {
+					string className = assetsManager.GetBaseField( assetFileInst, script ).Get( "m_ClassName" ).AsString;
+					scriptClasses.Add( script.PathId, className );
+				}
+				Dictionary<long, string> classNames = new();
+				foreach ( AssetFileInfo behaviour in assetFileInst.file.GetAssetsOfType( AssetClassID.MonoBehaviour ) ) {
+					AssetTypeValueField behaviourAsset = assetsManager.GetBaseField( assetFileInst, behaviour );
+					long scriptPathId = behaviourAsset.Get( "m_Script" ).Get( "m_PathID" ).AsLong;
+					if ( !scriptClasses.ContainsKey( scriptPathId ) ) {
+						throw new KeyNotFoundException( "Unable to identify script class for behaviour" );
+					}
+					assetsToolsNETBundle.Classes.Add( scriptClasses[scriptPathId], assetIDs[behaviour.PathId] );
+					assetsToolsNETBundle.AssetInfo.Add( assetIDs[behaviour.PathId], behaviour );
 				}
 			}
 			return assetBundles[path].AssetBundle;
@@ -89,11 +113,16 @@ namespace Mffer {
 			CheckAssetBundle( assetBundle );
 			if ( !assetBundle.Contains( assetName ) )
 				throw new KeyNotFoundException( $"Asset bundle {assetBundle.Path} does not contain an asset named '{assetName}'." );
+			string assetBundlePath = Path.GetFullPath( assetBundle.Path );
+			AssetsToolsNETBundle assetNETBundle = assetBundles[assetBundlePath];
+			if ( !assetNETBundle.AssetInfo.ContainsKey( assetName ) && assetNETBundle.Classes.ContainsKey( assetName ) ) {
+				assetName = assetNETBundle.Classes[assetName];
+			}
 			if ( !assetBundle.Assets.ContainsKey( assetName ) || assetBundle.Assets[assetName] is null ) {
-				assetBundle.Assets[assetName] = new Asset( assetBundles[assetBundle.Path].AssetInfo[assetName].PathId );
+				assetBundle.Assets[assetName] = new Asset( assetBundles[assetBundlePath].AssetInfo[assetName].PathId );
 			}
 			Asset asset = assetBundle.Assets[assetName];
-			AssetsFileInstance assetsFileInstance = assetsManager.LoadAssetsFileFromBundle( assetBundles[assetBundle.Path].AssetBundleInstance, 0 );
+			AssetsFileInstance assetsFileInstance = assetsManager.LoadAssetsFileFromBundle( assetBundles[assetBundlePath].AssetBundleInstance, 0 );
 			asset.PathID = assetBundles[assetBundle.Path].AssetInfo[assetName].PathId;
 			asset.Name = assetsManager.GetBaseField( assetsFileInstance, asset.PathID ).Get( "m_Name" ).AsString;
 			SortedDictionary<string, GameObject> children = new();
@@ -106,7 +135,10 @@ namespace Mffer {
 		/// <inheritdoc/>
 		public List<string> GetAllAssetNames( AssetBundle assetBundle ) {
 			CheckAssetBundle( assetBundle );
-			return assetBundles[assetBundle.Path].AssetInfo.Keys.ToList();
+			AssetsToolsNETBundle assetToolsNetBundle = assetBundles[Path.GetFullPath( assetBundle.Path )];
+			List<string> fullList = assetToolsNetBundle.AssetInfo.Keys.ToList();
+			fullList.AddRange( assetToolsNetBundle.Classes.Keys.ToList() );
+			return fullList;
 		}
 		/// <inheritdoc/>
 		public List<Asset> GetAllAssets( AssetBundle assetBundle ) {
@@ -140,7 +172,7 @@ namespace Mffer {
 			if ( assetBundle is null ) throw new ArgumentNullException( nameof( assetBundle ) );
 			if ( String.IsNullOrEmpty( assetBundle.Path ) ) throw new InvalidOperationException( "No path found for asset bundle" );
 			string path = Path.GetFullPath( assetBundle.Path );
-			if ( !assetBundles.ContainsKey( assetBundle.Path ) ) throw new InvalidOperationException( "This asset bundle was not loaded by this reader." );
+			if ( !assetBundles.ContainsKey( path ) ) throw new InvalidOperationException( "This asset bundle was not loaded by this reader." );
 		}
 		/// <summary>
 		/// Represents the collected objects associated with a single <see
@@ -161,6 +193,10 @@ namespace Mffer {
 			/// </summary>
 			internal Dictionary<string, AssetFileInfo> AssetInfo { get; }
 			/// <summary>
+			/// A mapping of class names to asset paths
+			/// </summary>
+			internal Dictionary<string, string> Classes { get; }
+			/// <summary>
 			/// Creates a new <see cref="AssetsToolsNETBundle"/> from the given objects
 			/// </summary>
 			/// <param name="path">Filesystem path to the <see cref="AssetBundle"/></param>
@@ -171,6 +207,7 @@ namespace Mffer {
 				AssetBundle.Path = path;
 				AssetBundleInstance = bundleFileInstance;
 				AssetInfo = new();
+				Classes = new();
 			}
 		}
 	}

--- a/src/classes/AssetsToolsNETReader.cs
+++ b/src/classes/AssetsToolsNETReader.cs
@@ -111,14 +111,14 @@ namespace Mffer {
 		/// within the provided <see cref="AssetBundle"/></exception>
 		public Asset GetAsset( string assetName, AssetBundle assetBundle ) {
 			CheckAssetBundle( assetBundle );
-			if ( !assetBundle.Contains( assetName ) )
-				throw new KeyNotFoundException( $"Asset bundle {assetBundle.Path} does not contain an asset named '{assetName}'." );
 			string assetBundlePath = Path.GetFullPath( assetBundle.Path );
 			AssetsToolsNETBundle assetNETBundle = assetBundles[assetBundlePath];
+			if ( !Contains( assetName, assetNETBundle ) )
+				throw new KeyNotFoundException( $"Asset bundle {assetBundle.Path} does not contain an asset named '{assetName}'." );
 			if ( !assetNETBundle.AssetInfo.ContainsKey( assetName ) && assetNETBundle.Classes.ContainsKey( assetName ) ) {
 				assetName = assetNETBundle.Classes[assetName];
 			}
-			if ( !assetBundle.Assets.ContainsKey( assetName ) || assetBundle.Assets[assetName] is null ) {
+			if ( !assetBundle.Assets.ContainsKey( assetName ) || assetBundle.Assets[assetName] is null || assetBundle.Assets[assetName].Value is null ) {
 				assetBundle.Assets[assetName] = new Asset( assetBundles[assetBundlePath].AssetInfo[assetName].PathId );
 			}
 			Asset asset = assetBundle.Assets[assetName];
@@ -137,7 +137,6 @@ namespace Mffer {
 			CheckAssetBundle( assetBundle );
 			AssetsToolsNETBundle assetToolsNetBundle = assetBundles[Path.GetFullPath( assetBundle.Path )];
 			List<string> fullList = assetToolsNetBundle.AssetInfo.Keys.ToList();
-			fullList.AddRange( assetToolsNetBundle.Classes.Keys.ToList() );
 			return fullList;
 		}
 		/// <inheritdoc/>

--- a/src/classes/IAssetReader.cs
+++ b/src/classes/IAssetReader.cs
@@ -13,8 +13,9 @@ namespace Mffer {
 		/// <param name="name">name of <see cref="Asset"/> to seek</param>
 		/// <param name="assetBundle"><see cref="AssetBundle"/> to
 		/// search</param>
-		/// <returns><c>true</c> if <paramref name="assetBundle"/> contains <paramref
-		/// name="name"/>, <c>false</c> otherwise</returns>
+		/// <returns><c>true</c> if <paramref name="assetBundle"/> contains an
+		/// asset named <paramref name="name"/> or an asset representing a class
+		/// named <paramref name="name"/>, <c>false</c> otherwise</returns>
 		public bool Contains( string name, AssetBundle assetBundle );
 		/// <summary>
 		/// Loads data from a file into a new <see cref="AssetBundle"/>
@@ -26,7 +27,7 @@ namespace Mffer {
 		/// <summary>
 		/// Obtain an <see cref="Asset"/> from an <see cref="AssetBundle"/>
 		/// </summary>
-		/// <param name="assetName">name of the <see cref="Asset"/></param>
+		/// <param name="assetName">name of the <see cref="Asset"/> or a class name represented by the asset</param>
 		/// <param name="assetBundle"><see cref="AssetBundle"/> containing the
 		/// <see cref="Asset"/></param>
 		/// <returns></returns>


### PR DESCRIPTION
- concurrently simplify some methods in AssetBundle
- make GetAllAssetNames() still return only true asset names, not
  the aliased class names